### PR TITLE
Enables queuing with an offset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'sh.blake.niouring'
-version '0.1.3'
+version '0.1.4'
 
 sourceCompatibility = 1.8
 

--- a/src/main/c/liburing_provider.c
+++ b/src/main/c/liburing_provider.c
@@ -210,7 +210,7 @@ Java_sh_blake_niouring_IoUring_queueConnect(JNIEnv *env, jclass cls, jlong ring_
 }
 
 JNIEXPORT jlong JNICALL
-Java_sh_blake_niouring_IoUring_queueRead(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len) {
+Java_sh_blake_niouring_IoUring_queueRead(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len, jlong io_offset) {
     void *buffer = (*env)->GetDirectBufferAddress(env, byte_buffer);
     if (buffer == NULL) {
         return throw_exception(env, "invalid byte buffer (read)", -EINVAL);
@@ -236,14 +236,14 @@ Java_sh_blake_niouring_IoUring_queueRead(JNIEnv *env, jclass cls, jlong ring_add
     req->buffer_addr = buffer;
     req->fd = fd;
 
-    io_uring_prep_read(sqe, fd, buffer + buffer_pos, buffer_len, 0);
+    io_uring_prep_read(sqe, fd, buffer + buffer_pos, buffer_len, (__u64) io_offset);
     io_uring_sqe_set_data(sqe, req);
 
     return (uint64_t) buffer;
 }
 
 JNIEXPORT jlong JNICALL
-Java_sh_blake_niouring_IoUring_queueWrite(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len) {
+Java_sh_blake_niouring_IoUring_queueWrite(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len, jlong io_offset) {
     void *buffer = (*env)->GetDirectBufferAddress(env, byte_buffer);
     if (buffer == NULL) {
         return throw_exception(env, "invalid byte buffer (write)", -EINVAL);
@@ -268,7 +268,7 @@ Java_sh_blake_niouring_IoUring_queueWrite(JNIEnv *env, jclass cls, jlong ring_ad
     req->buffer_addr = buffer;
     req->fd = fd;
 
-    io_uring_prep_write(sqe, fd, buffer + buffer_pos, buffer_len, 0);
+    io_uring_prep_write(sqe, fd, buffer + buffer_pos, buffer_len, (uint64_t) io_offset);
     io_uring_sqe_set_data(sqe, req);
 
     return (uint64_t) buffer;

--- a/src/main/c/liburing_provider.c
+++ b/src/main/c/liburing_provider.c
@@ -251,7 +251,7 @@ Java_sh_blake_niouring_IoUring_queueRead(JNIEnv *env, jclass cls, jlong ring_add
     req->buffer_addr = (int64_t) buffer;
     req->fd = fd;
 
-    io_uring_prep_read(sqe, fd, buffer + buffer_pos, buffer_len, (__u64) io_offset);
+    io_uring_prep_read(sqe, fd, buffer + buffer_pos, buffer_len, (uint64_t) io_offset);
     io_uring_sqe_set_data(sqe, req);
 
     return (uint64_t) buffer;

--- a/src/main/c/liburing_provider.h
+++ b/src/main/c/liburing_provider.h
@@ -32,10 +32,10 @@ JNIEXPORT void JNICALL
 Java_sh_blake_niouring_IoUring_queueConnect(JNIEnv *env, jclass cls, jlong ring_address, jint socket_fd, jstring ip_address, jint port);
 
 JNIEXPORT jlong JNICALL
-Java_sh_blake_niouring_IoUring_queueRead(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len);
+Java_sh_blake_niouring_IoUring_queueRead(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len, jlong io_offset);
 
 JNIEXPORT jlong JNICALL
-Java_sh_blake_niouring_IoUring_queueWrite(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len);
+Java_sh_blake_niouring_IoUring_queueWrite(JNIEnv *env, jclass cls, jlong ring_address, jint fd, jobject byte_buffer, jint buffer_pos, jint buffer_len, jlong io_offset);
 
 JNIEXPORT void JNICALL
 Java_sh_blake_niouring_IoUring_queueClose(JNIEnv *env, jclass cls, jlong ring_address, jint fd);

--- a/src/test/java/sh/blake/niouring/IoUringFileTest.java
+++ b/src/test/java/sh/blake/niouring/IoUringFileTest.java
@@ -12,14 +12,14 @@ public class IoUringFileTest extends TestBase {
 
     @Test
     public void open_and_read_readme_should_succeed() {
-        String fileName = "README.md";
+        String fileName = "src/test/resources/test-file.txt";
         AtomicBoolean readSuccessfully = new AtomicBoolean(false);
 
         IoUringFile file = new IoUringFile(fileName);
         file.onRead(in -> {
             in.flip();
             String fileStr = StandardCharsets.UTF_8.decode(in).toString();
-            if (fileStr.startsWith("# nio_uring")) {
+            if (fileStr.startsWith("Hello, world!")) {
                 readSuccessfully.set(true);
             }
         });
@@ -36,12 +36,10 @@ public class IoUringFileTest extends TestBase {
 
     @Test
     public void seek_read_readme_should_succeed() {
-        // This test is fragile and will need to be maintained
-        // as the README is updated.
-        String fileName = "README.md";
+        String fileName = "src/test/resources/test-file.txt";
         AtomicInteger readCounter = new AtomicInteger(0);
         AtomicBoolean seekSuccessfully = new AtomicBoolean(false);
-        int chunkSize = 1024;
+        int chunkSize = 7;
         ByteBuffer buffer = ByteBuffer.allocateDirect(chunkSize);
 
         IoUring ioUring = new IoUring(TEST_RING_SIZE)
@@ -56,7 +54,7 @@ public class IoUringFileTest extends TestBase {
             if (count == 1) {
                 in.clear(); // reuse the buffer provided
                 ioUring.queueRead(file, in, chunkSize); // read with offset
-            } else if (fileStr.startsWith("et = new IoUringServerSocket(8080);")) {
+            } else if (fileStr.startsWith("world!")) {
                 seekSuccessfully.set(true);
             }
         });

--- a/src/test/java/sh/blake/niouring/IoUringFileTest.java
+++ b/src/test/java/sh/blake/niouring/IoUringFileTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class IoUringFileTest extends TestBase {
 
@@ -31,5 +32,38 @@ public class IoUringFileTest extends TestBase {
         attemptUntil(ioUring::execute, readSuccessfully::get);
 
         Assert.assertTrue("File read successfully", readSuccessfully.get());
+    }
+
+    @Test
+    public void seek_read_readme_should_succeed() {
+        // This test is fragile and will need to be maintained
+        // as the README is updated.
+        String fileName = "README.md";
+        AtomicInteger readCounter = new AtomicInteger(0);
+        AtomicBoolean seekSuccessfully = new AtomicBoolean(false);
+        int chunkSize = 1024;
+        ByteBuffer buffer = ByteBuffer.allocateDirect(chunkSize);
+
+        IoUring ioUring = new IoUring(TEST_RING_SIZE)
+            .onException(Exception::printStackTrace);
+
+        IoUringFile file = new IoUringFile(fileName);
+        file.onRead(in -> {
+            in.flip();
+            int count = readCounter.incrementAndGet();
+            String fileStr = StandardCharsets.UTF_8.decode(in).toString();
+
+            if (count == 1) {
+                in.clear(); // reuse the buffer provided
+                ioUring.queueRead(file, in, chunkSize); // read with offset
+            } else if (fileStr.startsWith("et = new IoUringServerSocket(8080);")) {
+                seekSuccessfully.set(true);
+            }
+        });
+
+        ioUring.queueRead(file, buffer);
+        attemptUntil(ioUring::execute, seekSuccessfully::get);
+
+        Assert.assertTrue("File seek successfully", seekSuccessfully.get());
     }
 }

--- a/src/test/resources/test-file.txt
+++ b/src/test/resources/test-file.txt
@@ -1,0 +1,3 @@
+Hello, world!
+
+Do not change this file unless you want to fix broken unit tests!


### PR DESCRIPTION
This PR implements the changes discussed in #20, enabling callers to supply an offset queuing a read/write.
Existing behavior was preserved (a default offset of 0 when not supplied) and a test was added to the File tests.